### PR TITLE
examples/00_bmg_gemm.cpp: randomize buffers on CPU side instead of GPU side

### DIFF
--- a/examples/sycl/00_bmg_gemm/00_bmg_gemm.cpp
+++ b/examples/sycl/00_bmg_gemm/00_bmg_gemm.cpp
@@ -237,9 +237,9 @@ struct ExampleRunner {
     block_D.reset(static_cast<std::size_t>(M) * N * L);
     block_ref_D.reset(static_cast<std::size_t>(M) * N * L);
 
-    initialize_block(block_A, seed + 2023);
-    initialize_block(block_B, seed + 2022);
-    initialize_block(block_C, seed + 2021);
+    random_fill(block_A.get(), seed + 2023, block_A.size(), 1.0f, 0.0f);
+    random_fill(block_B.get(), seed + 2022, block_B.size(), 1.0f, 0.0f);
+    random_fill(block_C.get(), seed + 2021, block_C.size(), 1.0f, 0.0f);
   }
 
   cutlass::Status run(const Options& options, const cutlass::KernelHardwareInfo& hw_info) {


### PR DESCRIPTION
It is time consuming to randomly initialize buffer on some cases due to GPU kernel overhead.

Switch to CPU randomization + H2D transfer as a general solution since we cannot detect the special cases.

Signed-off-by: Yuan, Feng <feng1.yuan@intel.com>
Signed-off-by: Guo, Yejun <yejun.guo@intel.com>