### PR TITLE
 Improve Device-Side Random Uniform Filling by Reusing Host Implementation in SYCL

### DIFF
--- a/tools/util/include/cutlass/util/reference/device/sycl_tensor_fill.h
+++ b/tools/util/include/cutlass/util/reference/device/sycl_tensor_fill.h
@@ -181,7 +181,7 @@ void BlockFillRandomUniformCopyFromHost(
   int bits = -1                           ///< If non-negative, specifies number of fractional bits that
                                           ///  are not truncated to zero. Permits reducing precision of
                                           ///  data.
-) {
+  ) {
   auto buff = std::vector<Element>(capacity);
 
   cutlass::reference::host::BlockFillRandomUniform(buff.data(), capacity, seed, max, min, bits);

--- a/tools/util/include/cutlass/util/reference/device/sycl_tensor_fill.h
+++ b/tools/util/include/cutlass/util/reference/device/sycl_tensor_fill.h
@@ -176,8 +176,10 @@ void BlockFillRandomUniformCopyFromHost(
   size_t capacity,
   uint64_t seed,                          ///< seed for RNG
   typename RealType<Element>::Type max,   ///< upper bound of distribution
-  typename RealType<Element>::Type min,    ///< lower bound for distribution
-  int bits = -1
+  typename RealType<Element>::Type min,   ///< lower bound for distribution
+  int bits = -1                           ///< If non-negative, specifies number of fractional bits that
+                                          ///  are not truncated to zero. Permits reducing precision of
+                                          ///  data.
 ) {
   auto buff = std::vector<Element>(capacity);
 

--- a/tools/util/include/cutlass/util/reference/device/sycl_tensor_fill.h
+++ b/tools/util/include/cutlass/util/reference/device/sycl_tensor_fill.h
@@ -1,5 +1,6 @@
 /***************************************************************************************************
 * Copyright (c) 2024 - 2024 Codeplay Software Ltd. All rights reserved.
+* Copyright (c) 2025 Intel Corporation, All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without

--- a/tools/util/include/cutlass/util/reference/device/sycl_tensor_fill.h
+++ b/tools/util/include/cutlass/util/reference/device/sycl_tensor_fill.h
@@ -44,9 +44,9 @@
 #include "cutlass/cutlass.h"
 #include "cutlass/complex.h"
 #include "cutlass/util/reference/device/tensor_foreach.h"
+#include "cutlass/util/reference/host/tensor_fill.h"
 #include "cutlass/tensor_view.h"
 #include "cutlass/layout/vector.h"
-#include "cutlass/util/reference/host/tensor_fill.h"
 
 
 namespace cutlass {


### PR DESCRIPTION
1. Generates random data on the host and copies it to the device via syclcompat::memcpy, improving code reuse and supporting a broader range of element types.
2.  An optional bits parameter to control fractional precision, which was not present in the original.