### PR TITLE
Fix CUTLASS Py Lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ if (CUTLASS_ENABLE_SYCL)
 
   if (CUTLASS_SYCL_PROFILING_ENABLED)
     add_compile_definitions(CUTLASS_SYCL_PROFILING_ENABLED)
-    add_compile_definitions(SYCLCOMPAT_PROFILING_ENABLED)
+    add_compile_definitions(COMPAT_PROFILING_ENABLED)
   endif()
 
   if (CUTLASS_SYCL_BUILTIN_ENABLE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-  "cuda-python>=11.8.0",
   "networkx",
   "numpy",
   "pydot",

--- a/python/cutlass/backend/compiler.py
+++ b/python/cutlass/backend/compiler.py
@@ -359,7 +359,7 @@ class ArtifactManager:
                     file.write(source_buffer_device)
 
                 # Compile with DPC++
-                cmd_template = "clang++ ${options} ${srcfile} -o ${outfile} -fsycl-dump-device-code=${tmpdir}"
+                cmd_template = "icpx ${options} ${srcfile} -o ${outfile} -fsycl-dump-device-code=${tmpdir}"
                 values = {
                     "options": compilation_options.get_str(),
                     "srcfile": temp_cpp.name,
@@ -441,7 +441,7 @@ class ArtifactManager:
             cmd.extend(["-shared", "-o", temp_dst.name,
                         temp_src.name, "-lcudart", "-lcuda"])
         else:
-            cmd.append("clang++")
+            cmd.append("icpx")
             # Clang does not support "-fpermissive"
             cmd.extend(["-fsycl", "-w", "-fPIC"])
             cmd.extend(host_compilation_options.get_str().split(" "))

--- a/python/cutlass/backend/compiler.py
+++ b/python/cutlass/backend/compiler.py
@@ -218,7 +218,7 @@ class ArtifactManager:
             key, cubin_image, host_binary, operation_name, op_attr = row
             op_attr = json.loads(op_attr)
             if self._is_sycl():
-                q = dpctl.SyclQueue(cutlass.sycl_device())
+                q = dpctl.SyclQueue(cutlass_cppgen.sycl_device())
                 module = dpctl.program.create_program_from_spirv(
                     q, cubin_image)
                 kernel = module.get_sycl_kernel(operation_name)
@@ -378,7 +378,7 @@ class ArtifactManager:
                 # generates multiple SPIR-V files. We create a program from each of
                 # them to find the one containing the kernel with the correct
                 # subgroup size.
-                q = dpctl.SyclQueue(cutlass.sycl_device())
+                q = dpctl.SyclQueue(cutlass_cppgen.sycl_device())
                 op_name = f"__sycl_kernel_{operation_list[0].name()}"
                 cubin_image = None
                 for f in spv_files:
@@ -472,7 +472,7 @@ class ArtifactManager:
             host_compile_options = CompilationOptions(
                 self._nvcc_compile_options, arch, include_paths, False)
         else:
-            cutlass.initialize_sycl_context()
+            cutlass_cppgen.initialize_sycl_context()
             arch = "intel_gpu_pvc"
             host_compile_options = CompilationOptions(
                 ["-std=c++17", "-DCUTLASS_ENABLE_SYCL", "-DSYCL_INTEL_TARGET"],
@@ -515,7 +515,7 @@ class ArtifactManager:
             if self._is_sycl():
                 if cubin_image is None:
                     raise RuntimeError("SYCL compilation failed, see debug log")
-                q = dpctl.SyclQueue(cutlass.sycl_device())
+                q = dpctl.SyclQueue(cutlass_cppgen.sycl_device())
                 program = dpctl.program.create_program_from_spirv(
                     q, cubin_image)
             else:

--- a/python/cutlass/backend/memory_manager.py
+++ b/python/cutlass/backend/memory_manager.py
@@ -92,7 +92,7 @@ def _todevice(host_data, stream):
     """
     if cutlass_cppgen.use_rmm:
         return rmm.DeviceBuffer.to_device(host_data.tobytes())
-    if cutlass._use_sycl:
+    if cutlass_cppgen._use_sycl:
         nbytes = len(host_data.tobytes())
         usm_device_ptr = device_mem_alloc(nbytes, stream)
         stream.memcpy(usm_device_ptr.usm_mem, host_data.tobytes(), nbytes)
@@ -124,7 +124,7 @@ def todevice(host_data, dtype=np.float32, stream = None):
 def device_mem_alloc(size, stream = None):
     if cutlass_cppgen.use_rmm:
         return rmm.DeviceBuffer(size=size)
-    elif cutlass._use_sycl:
+    elif cutlass_cppgen._use_sycl:
         device_usm = MemoryUSMDevice(size, queue=stream)
         return SYCLPtrWrapper(device_usm)
     else:

--- a/python/cutlass/backend/utils/device.py
+++ b/python/cutlass/backend/utils/device.py
@@ -80,7 +80,7 @@ def device_cc(device: int = -1) -> int:
     if device == -1:
         device = cutlass_cppgen.device_id()
 
-    if cutlass._use_sycl:
+    if cutlass_cppgen._use_sycl:
         # Using '11' to encode Intel PVC as an integer in the expected format.
         return 11
 
@@ -94,8 +94,8 @@ def device_sm_count(device: int = -1):
     if device == -1:
         device = cutlass_cppgen.device_id()
 
-    if cutlass._use_sycl:
-        return cutlass._sycl_device.max_compute_units
+    if cutlass_cppgen._use_sycl:
+        return cutlass_cppgen._sycl_device.max_compute_units
 
     err, device_sm_count = cuda.cuDeviceGetAttribute(
         cuda.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT, device
@@ -136,6 +136,6 @@ def to_device_ptr(tensor) -> cuda.CUdeviceptr:
 
 
 def default_stream():
-    if cutlass._use_sycl:
-        return dpctl.SyclQueue(cutlass._sycl_device)
+    if cutlass_cppgen._use_sycl:
+        return dpctl.SyclQueue(cutlass_cppgen._sycl_device)
     return cuda.CUstream(0)

--- a/python/cutlass/op/gemm.py
+++ b/python/cutlass/op/gemm.py
@@ -626,7 +626,7 @@ class Gemm(OperationBase):
 
     def run(self, A=None, B=None, C=None, D=None,
             alpha=None, beta=None, sync: bool = True, print_module: bool = False, visitor_args: dict = None,
-            stream = default_stream()) -> GemmArguments:
+            stream = None) -> GemmArguments:
         """
         Runs the kernel currently specified. If it has not already been, the kernel is emitted and
         compiled. Tensors holding operands and outputs of the kernel are sourced either from the
@@ -649,14 +649,14 @@ class Gemm(OperationBase):
         :type sync: bool
         :param print_module: whether to print the emitted C++ code
         :type print_module: bool
-        :param stream: cuda stream, defaults to cuda.cuda.CUstream(0)
+        :param stream: cuda stream, defaults to the default stream
         :type stream: :class:`cuda.cuda.CUstream`
 
         :return: arguments passed in to the kernel
         :rtype: cutlass_cppgen.backend.GemmArguments
         """
-        if not stream:
-            stream = cuda.CUstream(0)
+        if stream is None:
+            stream = default_stream()
         super().run_setup()
         A = self._verify_tensor(A, self.A, self._element_a, self._layout_a, "A")
         B = self._verify_tensor(B, self.B, self._element_b, self._layout_b, "B")

--- a/python/cutlass/op/gemm.py
+++ b/python/cutlass/op/gemm.py
@@ -131,7 +131,7 @@ from cutlass_cppgen.backend import compiler
 from cutlass_cppgen.backend.evt import EpilogueFunctorVisitor
 from cutlass_cppgen.backend.gemm_operation import GemmArguments, GemmOperationUniversal
 from cutlass_cppgen.backend.library import TensorDescription, TileDescription
-from cutlass.backend.utils.device import default_stream
+from cutlass_cppgen.backend.utils.device import default_stream
 from cutlass_cppgen.op.op import OperationBase
 from cutlass_cppgen.shape import GemmCoord
 from cutlass_cppgen.utils import check, datatypes

--- a/test/python/cutlass/gemm/gemm_bf16_pvc.py
+++ b/test/python/cutlass/gemm/gemm_bf16_pvc.py
@@ -38,19 +38,19 @@ from functools import partial
 import logging
 import unittest
 
-import cutlass
-from cutlass.backend.utils.device import device_cc
+import cutlass_cppgen
+from cutlass_cppgen.backend.utils.device import device_cc
 
 from utils import LayoutCombination, add_test_gemm
 
 
-cutlass.set_log_level(logging.WARNING)
+cutlass_cppgen.set_log_level(logging.WARNING)
 cc = 11
-dtype = cutlass.DataType.bf16
+dtype = cutlass_cppgen.DataType.bf16
 
 
 @unittest.skipIf(device_cc() != cc, 'Device compute capability is insufficient for PVC tests.')
-@unittest.skipIf(cutlass.utils.datatypes.torch_type(dtype) is None, f'Version of torch installed does not contain a datatype match for {dtype}')
+@unittest.skipIf(cutlass_cppgen.utils.datatypes.torch_type(dtype) is None, f'Version of torch installed does not contain a datatype match for {dtype}')
 class GemmBF16PVC(unittest.TestCase):
     """
     Wrapper class to which tests will be added dynamically in __main__
@@ -61,18 +61,18 @@ class GemmBF16PVC(unittest.TestCase):
 add_test_pvc_bf16 = partial(add_test_gemm, cls=GemmBF16PVC, cc=11,
                             element=dtype,
                             compilation_modes=["dpcpp"],
-                            opclass=cutlass.OpcodeClass.TensorOp,
+                            opclass=cutlass_cppgen.OpcodeClass.TensorOp,
                             stages=0,
                             cluster_shape=[1, 1, 1])
 
 add_test_f32_acc = partial(add_test_pvc_bf16, alignments=[2, 2, 4],
-                           element_C=cutlass.DataType.f32,
-                           element_output=cutlass.DataType.f32,
-                           element_accumulator=cutlass.DataType.f32)
+                           element_C=cutlass_cppgen.DataType.f32,
+                           element_output=cutlass_cppgen.DataType.f32,
+                           element_accumulator=cutlass_cppgen.DataType.f32)
 add_test_bf16_acc = partial(add_test_pvc_bf16, alignments=[2, 2, 2],
-                            element_C=cutlass.DataType.bf16,
-                            element_output=cutlass.DataType.bf16,
-                            element_accumulator=cutlass.DataType.bf16)
+                            element_C=cutlass_cppgen.DataType.bf16,
+                            element_output=cutlass_cppgen.DataType.bf16,
+                            element_accumulator=cutlass_cppgen.DataType.bf16)
 
 add_test_f32_acc(layouts=LayoutCombination.TTT,
                  threadblock_shape=[256, 256, 32], warp_count=[8, 4, 1])

--- a/test/python/cutlass/gemm/gemm_testbed.py
+++ b/test/python/cutlass/gemm/gemm_testbed.py
@@ -37,8 +37,9 @@ import subprocess
 
 import cutlass_cppgen
 import torch
+import os
 
-if not cutlass_cppgen._use_sycl:
+if not os.getenv("CUTLASS_USE_SYCL"):
     import cuda
 import dpctl
 

--- a/test/python/cutlass/gemm/gemm_testbed.py
+++ b/test/python/cutlass/gemm/gemm_testbed.py
@@ -35,9 +35,11 @@ import os
 import re
 import subprocess
 
+import cutlass_cppgen
 import torch
 
-import cuda
+if not cutlass_cppgen._use_sycl:
+    import cuda
 import dpctl
 
 from cutlass_library import (

--- a/test/python/cutlass/gemm/utils.py
+++ b/test/python/cutlass/gemm/utils.py
@@ -247,6 +247,13 @@ def add_test_gemm(
             td.threadblock_shape = threadblock_shape
             td.stages = stages
             td.cluster_shape = cluster_shape
+            
+            # For Intel PVC (CC 11), ensure we use auto schedules and default tile scheduler
+            if cc == 11:
+                td.kernel_schedule = cutlass_cppgen.KernelScheduleType.ScheduleAuto
+                td.epilogue_schedule = cutlass_cppgen.EpilogueScheduleType.ScheduleAuto
+                td.tile_scheduler = cutlass_cppgen.TileSchedulerType.Default
+            
             op = plan.construct(tile_description=td, alignment_A=alignment_A, alignment_B=alignment_B, alignment_C=alignment_C)
             self.assertTrue(test_all_gemm(op, 'universal', compilation_mode=compilation_mode))
 


### PR DESCRIPTION
The default_stream() was removed from parameters, as when the module is called `import cutlass_cppgen` the default parameter values in Python are evaluated at function definition time (when the module is imported). Due to this the `_use_sycl=True` isn't set correctly as device_id() is not called during import, and it fallbacks to cuda. Now with this change `import cutlass_cppgen` can be imported without worrying about SYCL/CUDA usage. 