### PR TITLE
[Reorder] add optimized e8m0 -> f32 upconversion

### DIFF
--- a/include/cute/arch/reorder_xe.hpp
+++ b/include/cute/arch/reorder_xe.hpp
@@ -1236,7 +1236,33 @@ struct Xe_Reorder<ReorderKind::VV, float_e2m1_t, bfloat16_t>
   }
 };
 
+template <>
+struct Xe_Reorder<ReorderKind::UU, float_ue8m0_t, float>
+{
+  using SRegisters = intel::uchar4[1];
+  using DRegisters = intel::float4[1];
 
+  CUTE_HOST_DEVICE static void
+  reorder(intel::uchar4 const& src0, intel::float4& dst0)
+  {
+#if defined(CUTE_ARCH_COPY_XE_ENABLED)
+    asm (     /* 2 cycles/output register */
+      "{\n"
+      ".decl IN_UB v_type=G type=UB num_elts=64 alias=<%1,0>\n"
+      ".decl OUT_UW v_type=G type=UW num_elts=128 alias=<%0,0>\n"
+      "shl (M1_NM, 32) OUT_UW(0,1)<2> IN_UB(0,0)<1;1,0>   7:uw\n"
+      "shl (M1_NM, 32) OUT_UW(2,1)<2> IN_UB(0,32)<1;1,0>  7:uw\n"
+      "add.sat (M1_NM, 32) OUT_UW(0,0)<2> IN_UB(0,0)<1;1,0>  -254:w\n"
+      "add.sat (M1_NM, 32) OUT_UW(2,0)<2> IN_UB(0,32)<1;1,0> -254:w\n"
+      "}\n"
+      : "=rw"(dst0)
+      : "rw"(src0)
+    );
+#else
+  CUTE_INVALID_CONTROL_PATH("Not Xe");
+#endif
+  }
+};
 
 
 } // end namespace cute


### PR DESCRIPTION
Small PR to add e8m0 -> f32 upconversion for use with MXFP types.